### PR TITLE
Interstellar Extended Lithium Air Battery Support

### DIFF
--- a/GameData/Bumblebee/Patches/Interstellar.cfg
+++ b/GameData/Bumblebee/Patches/Interstellar.cfg
@@ -1,23 +1,19 @@
 @PART[bb_Core]:NEEDS[WarpPlugin]
 {
-    @description ^= :$: Includes high capacity Lithium Air battery for extended flight time.
+    	@description ^= :$: Includes high capacity Lithium Air battery for extended flight time.
 
 	@RESOURCE[ElectricCharge]
 	{
-	@amount = 800.0
-	@maxAmount = 800.0
+		@amount = 800.0
+		@maxAmount = 800.0
 	}
 
-	// From the Lithium Air battery, resized down to 0.950m
-	// then rounded down to an even number. The bumblebee can
-	// carry that battery around with it.
-	
 	RESOURCE
-    {
+	{
 		name = KilowattHour
-		amount = 40
-		maxAmount = 40
-    }
+		amount = 15
+		maxAmount = 15
+    	}
 
 	// From Interstellar EC2503.cfg
 
@@ -41,12 +37,12 @@
 		secondaryNormalizedDensity = 2.77777777777e-4	// 1 / 3600
 	}
 
-    MODULE
-    {
+    	MODULE
+    	{
 		name		=	ModuleElementRadioactiveDecay
 		decayConstant 	=	1.0e-6
 		resourceName	=	KilowattHour
 		decayProduct	=	WasteHeat
 		convFactor	=	0.001
-    }
+    	}
 }

--- a/GameData/Bumblebee/Patches/Interstellar.cfg
+++ b/GameData/Bumblebee/Patches/Interstellar.cfg
@@ -1,0 +1,52 @@
+@PART[bb_Core]:NEEDS[WarpPlugin]
+{
+    @description ^= :$: Includes high capacity Lithium Air battery for extended flight time.
+
+	@RESOURCE[ElectricCharge]
+	{
+	@amount = 800.0
+	@maxAmount = 800.0
+	}
+
+	// From the Lithium Air battery, resized down to 0.950m
+	// then rounded down to an even number. The bumblebee can
+	// carry that battery around with it.
+	
+	RESOURCE
+    {
+		name = KilowattHour
+		amount = 40
+		maxAmount = 40
+    }
+
+	// From Interstellar EC2503.cfg
+
+	MODULE
+	{
+		name = InterstellarDynamicResourceBuffer
+		resourceName = ElectricCharge
+		bufferSize = 800
+	}
+
+	MODULE
+	{
+		name = InterstellarResourceConverter
+		primaryResourceNames = KilowattHour
+		secondaryResourceNames = ElectricCharge
+		maxPowerPrimary = 8725
+		maxPowerSecondary = 8725
+		primaryConversionCostPower = false
+		secondaryConversionCostPower = false
+		primaryNormalizedDensity = 1
+		secondaryNormalizedDensity = 2.77777777777e-4	// 1 / 3600
+	}
+
+    MODULE
+    {
+		name		=	ModuleElementRadioactiveDecay
+		decayConstant 	=	1.0e-6
+		resourceName	=	KilowattHour
+		decayProduct	=	WasteHeat
+		convFactor	=	0.001
+    }
+}


### PR DESCRIPTION
This patch adds support for Interstellar Extended's top of the line battery part, the Lithium Air battery. I resized the battery down to get an accurate KilowattHour that the Bumblebee could carry around with it.